### PR TITLE
軌跡に垂直な面をつないで立体にする

### DIFF
--- a/Geom.hpp
+++ b/Geom.hpp
@@ -25,6 +25,9 @@ struct Point3 {
     }
     void normalize() {
         double length = std::sqrt(sum_sq());
+        if (length == 0) {
+            return;
+        }
         x /= length; y /= length; z /= length;
     }
 };
@@ -35,7 +38,7 @@ double dot_prod(const Point3 a, const Point3 b) {
 
 Point3 cross_prod(const Point3 a, const Point3 b) {
     double cx = a.y * b.z - a.z * b.y;
-    double cy = -a.x * b.z + a.z * b.y;
+    double cy = -a.x * b.z + a.z * b.x;
     double cz = a.x * b.y - a.y * b.x;
     return { cx, cy, cz };
 }

--- a/Geom.hpp
+++ b/Geom.hpp
@@ -32,11 +32,11 @@ struct Point3 {
     }
 };
 
-double dot_prod(const Point3 a, const Point3 b) {
+double dot_prod(const Point3& a, const Point3& b) {
     return a.x * b.x + a.y * b.y + a.z * b.z;
 }
 
-Point3 cross_prod(const Point3 a, const Point3 b) {
+Point3 cross_prod(const Point3& a, const Point3& b) {
     double cx = a.y * b.z - a.z * b.y;
     double cy = -a.x * b.z + a.z * b.x;
     double cz = a.x * b.y - a.y * b.x;

--- a/TraceCenterObj3D.hpp
+++ b/TraceCenterObj3D.hpp
@@ -7,11 +7,16 @@ struct TraceCenterObj3D : public TraceObj3D {
         const std::vector<double>& xs,
         const std::vector<double>& ys,
         const std::vector<Slice>& _slices, // WARGING: will move
-        double _length_per_time = 1,
+        double _total_length = 100,
         bool _is_same_slice = false
     ) {
+        if (xs.size() != ys.size()) {
+            std::cerr << "TraceCenterObj3D: not same size points\n";
+            std::exit(1);
+        }
         is_same_slice = _is_same_slice;
-        LENGTH_PER_TIME = _length_per_time;
+        TOTAL_LENGTH = _total_length;
+        double length_per_time = TOTAL_LENGTH / xs.size();
         if (!_is_same_slice && _slices.size() < 3) {
             std::cerr << "slice is not enough\n";
             std::exit(1);
@@ -22,13 +27,13 @@ struct TraceCenterObj3D : public TraceObj3D {
         double z = 0.0;
         for (PointSize i = 0; i < xs.size(); i++) {
             center_points.emplace_back(Geom::Point3{ xs[i], ys[i], z });
-            z += LENGTH_PER_TIME;
+            z += length_per_time;
         }
 
         from_slices();
     };
 
-    double LENGTH_PER_TIME = 1;
+    double TOTAL_LENGTH = 100;
     std::vector<Geom::Point3> center_points;
     std::vector<Geom::Point3> norm_vecs;
     bool is_same_slice = false;

--- a/TraceCenterObj3D.hpp
+++ b/TraceCenterObj3D.hpp
@@ -7,8 +7,9 @@ struct TraceCenterObj3D : public TraceObj3D {
         const std::vector<double>& xs,
         const std::vector<double>& ys,
         const std::vector<Slice>& _slices, // WARGING: will move
+        double _length_per_time = 1,
         bool _is_same_slice = false
-    ) : is_same_slice(_is_same_slice) {
+    ) : is_same_slice(_is_same_slice), LENGTH_PER_TIME(_length_per_time) {
         if (!_is_same_slice && _slices.size() < 3) {
             std::cerr << "slice is not enough\n";
             std::exit(1);
@@ -17,13 +18,15 @@ struct TraceCenterObj3D : public TraceObj3D {
         center_points.clear();
         center_points.reserve(xs.size());
         double z = 0.0;
-        for (PointSize i = 0; i < xs.size(); i++, z++) {
+        for (PointSize i = 0; i < xs.size(); i++) {
             center_points.emplace_back(Geom::Point3{ xs[i], ys[i], z });
+            z += LENGTH_PER_TIME;
         }
 
         from_slices();
     };
 
+    double LENGTH_PER_TIME = 1;
     std::vector<Geom::Point3> center_points;
     std::vector<Geom::Point3> norm_vecs;
     bool is_same_slice = false;

--- a/TraceCenterObj3D.hpp
+++ b/TraceCenterObj3D.hpp
@@ -1,0 +1,100 @@
+#include "Geom.hpp"
+#include "TraceObj3D.hpp"
+
+struct TraceCenterObj3D : public TraceObj3D {
+
+    TraceCenterObj3D(
+        const std::vector<double>& xs,
+        const std::vector<double>& ys,
+        const std::vector<Slice>& _slices, // WARGING: will move
+        bool _is_same_slice = false
+    ) : is_same_slice(_is_same_slice) {
+        if (!_is_same_slice && _slices.size() < 3) {
+            std::cerr << "slice is not enough\n";
+            std::exit(1);
+        }
+        this->slices = std::move(_slices);
+        center_points.clear();
+        center_points.reserve(xs.size());
+        double z = 0.0;
+        for (PointSize i = 0; i < xs.size(); i++, z++) {
+            center_points.emplace_back(Geom::Point3{ xs[i], ys[i], z });
+        }
+
+        from_slices();
+    };
+
+    std::vector<Geom::Point3> center_points;
+    std::vector<Geom::Point3> norm_vecs;
+    bool is_same_slice = false;
+    bool make_points() override;
+    void make_norm_vecs();
+    void make_points_from_norm(const Geom::Point3 n, const Geom::Point3& a, const std::vector<Geom::Point2>& points2D);
+};
+
+void TraceCenterObj3D::make_norm_vecs() {
+    norm_vecs.clear();
+    norm_vecs.reserve(center_points.size() - 2);
+    for (PointIdx i = 0; i < center_points.size() - 2; i++) {
+        norm_vecs.emplace_back(Geom::Point3{
+            center_points[i + 2].x - center_points[i].x,
+            center_points[i + 2].y - center_points[i].y,
+            center_points[i + 2].z - center_points[i].z,
+        });
+        norm_vecs[i].normalize();
+    }
+}
+
+void TraceCenterObj3D::make_points_from_norm(const Geom::Point3 n, const Geom::Point3& a, const std::vector<Geom::Point2>& points2D) {
+    Geom::Point3 t { 0.0, 1.0, 0.0 };
+    Geom::Point3 t_sub { 0.0, 0.0, 1.0 };
+    Geom::Point3 u, v;
+    double cos_theta = Geom::dot_prod(n, t);
+    if (cos_theta > 0.99) {
+        u = Geom::cross_prod(t_sub, n);
+        u.normalize();
+    } else {
+        u = Geom::cross_prod(t, n);
+        u.normalize();
+    }
+    v = Geom::cross_prod(n, u);
+    v.normalize();
+    points.reserve(points2D.size());
+    for (const auto& p : points2D) {
+        points.emplace_back(Geom::Point3{
+            p.x * u.x + p.y * v.x + a.x,
+            p.x * u.y + p.y * v.y + a.y,
+            p.x * u.z + p.y * v.z + a.z,
+        });
+    }
+}
+
+bool TraceCenterObj3D::make_points() {
+    PointSize slice_size = slices.size();
+    if (slice_size == 0) { return false; }
+    PointSize slice_point_size = slices[0].points.size();
+
+    make_points_from_norm(
+        Geom::Point3{0, 0, 1}, 
+        center_points[0],
+        slices[0].points
+    );
+
+    make_norm_vecs();
+    for (PointSize i = 0; i < norm_vecs.size(); i++) {
+        PointIdx si = is_same_slice ? 0 : i+1;
+        make_points_from_norm(
+            norm_vecs[i],
+            center_points[i + 1],
+            slices[si].points
+        );
+    }
+
+    make_points_from_norm(
+        Geom::Point3{0, 0, 1}, 
+        center_points.back(),
+        slices.back().points
+    );
+
+    return true;
+}

--- a/TraceCenterObj3D.hpp
+++ b/TraceCenterObj3D.hpp
@@ -21,7 +21,19 @@ struct TraceCenterObj3D : public TraceObj3D {
             std::cerr << "slice is not enough\n";
             std::exit(1);
         }
-        this->slices = std::move(_slices);
+        if (_is_same_slice && _slices.size() != 1) {
+            std::cerr << "single slice with is_same_slice flag\n";
+            std::exit(1);
+        }
+
+        slices = std::move(_slices);
+
+        // これらは親クラスの変数
+        step_size = xs.size();
+        point_size_per_step = slices[0].points.size();
+        first_slice = slices[0];
+        last_slice = slices.back();
+
         center_points.clear();
         center_points.reserve(xs.size());
         double z = 0.0;
@@ -30,10 +42,14 @@ struct TraceCenterObj3D : public TraceObj3D {
             z += length_per_time;
         }
 
-        from_slices();
+        if (!from_slices()) {
+            std::cerr << "Error: in TraceCenterObj3D constuctor\n";
+            std::exit(1);
+        }
     };
 
     double TOTAL_LENGTH = 100;
+    std::vector<Slice> slices;
     std::vector<Geom::Point3> center_points;
     std::vector<Geom::Point3> norm_vecs;
     bool is_same_slice = false;

--- a/TraceCurveObj3D.hpp
+++ b/TraceCurveObj3D.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "TraceCenterObj3D.hpp"
+
+Slice get_circle(double r) {
+    Slice circle;
+    int pn = 50;
+    double pi = std::acos(-1);
+    circle.points.reserve(pn);
+    for (int i = 0; i < pn; i++) {
+        double th = (double)i / pn * 2 * pi;
+        circle.points.emplace_back(Geom::Point2{
+            r * std::cos(th), r * std::sin(th)
+        });
+    }
+    return circle;
+}
+
+struct TraceCurveObj3D : public TraceCenterObj3D {
+    TraceCurveObj3D(
+        const std::vector<double>& xs,
+        const std::vector<double>& ys,
+        double _total_length = 100,
+        double radius = 1
+    ) : TraceCenterObj3D(xs, ys, {get_circle(radius)}, _total_length, true) {
+    }
+};
+

--- a/gen_curve_obj.cpp
+++ b/gen_curve_obj.cpp
@@ -1,0 +1,21 @@
+#include "TraceCurveObj3D.hpp"
+
+#include <iostream>
+#include <vector>
+
+int main(int argc, char** argv) {
+    std::vector<double>xs, ys;
+    double x, y;
+    while (std::cin >> x >> y) {
+        xs.push_back(x);
+        ys.push_back(y);
+    }
+
+    double total_length = 110;
+    if (argc >= 2) {
+        total_length = std::stof(argv[1]);
+    }
+
+    TraceCurveObj3D obj{xs, ys, total_length};
+    std::cout << obj;
+}


### PR DESCRIPTION
# 軌跡に垂直な面をつないで立体にする

## `TraceCenterObj3D`

`TraceObj3D` を継承する.

### 法線ベクトルから面を作るときの方針

ベクトル ${n}$ ($|{n}| = 1$) に対して, これを法線とする平面に2Dの座標 $(p_x, p_y)$ をマッピングする.
1. ${n}$ と平行でない長さ $1$ の適当なベクトル ${t}$ を用意する
2. ${u} = {t} \times {n}$ とし, ${u}$ を正規化する
3. ${v} = {t} \times {n}$ とし, ${v}$ を正規化する
4. $p_x {u} + p_y {v}$ を対応する点とする

${t}$ の取り方について, 最初は ${t} = (0, 1, 0)$ として, ほぼ平行だったら $(0, 0, 1)$ に切り替える.
2回目以降は直前の ${v}$ を ${t}$ として使うと, 直前に作った平面とつないだ時に自然な座標系が得られる.

### コンストラクタ

引数:
- `const std::vector<double>& xs`
    - 軌跡の中心の $x$ 座標
- `const std::vector<double>& ys`
    - 軌跡の中心の $y$ 座標
- `const std::vector<Slice>& _slices`
    - それぞれの面にマップされる2D図形
- `double _total_length = 100`
    - 全体の積み上げ方向の長さ
- `bool _is_same_slice = false`
    - 全ての面に同じスライスを適応するか

### メンバ関数

- `bool make_points() override`
    - 親クラスの関数をオーバーライド
    - 最初の面, 中間の面, 最後の面の順に点を作る
    - `make_norm_vecs` を呼ぶ
    - それぞれの面の点を作るのに `make_points_from_norm` を呼ぶ
    - `check_intersect` を呼び, 戻り値が `false` ならエラーメッセージを出し, `false` を返す. それ以外は `true` を返す
- `void make_norm_vecs()`
    - 中間の面のそれぞれの法線を計算する
- `Geom::Point3 make_points_from_norm(const Geom::Point3& n, const Geom::Point3& t_main, const Geom::Point3& a, const std::vector<Geom::Point2>& points2D)`
    - `n` を法線とする `a` を通る平面に `points2D` を上記の方法でマッピングした点を追加する
    - `t_main` は ${t}$ の初期値
    - ${v}$ に対応する値を戻り値とする
- `bool check_intersect() const`
    - 全ての中間の面に対して以下を調べる
        - 今見ている面の一つ前の面を作る点が全て, 今の面の後ろ側にある
        - 今見ている面の一つ後の面を作る点が全て, 今の面の前側にある
    - 判定のため `is_front_points` を呼ぶ
- `bool is_front_points(const Geom::Point3& n, const Geom::Point3& o, PointIdx start, PointIdx end) const`
    - `start` から `end` の添え字 `i` について, `points[i]` が`n` を法線とする `o` を通る平面から見て `n` 側にあるかを調べる
    - 各点 ${p}$ について, $({p} - {o}) \cdot {n} > 0$ ならばその時に限り `true` を返す

## `TraceCurveObj3D`

`TraceCenterObj3D` を継承する.
スライスとして, 全て同じ円を適用する.

### コンストラクタ

引数:
- `const std::vector<double>& xs`
    - 軌跡の中心の $x$ 座標
- `const std::vector<double>& ys`
    - 軌跡の中心の $y$ 座標
- `double _total_length = 100`
    - 全体の積み上げ方向の長さ
- `double radius = 1`
    - スライスの円の半径

## メインプログラム

`gen_curve_obj.cpp` は標準入力した $(x_0, y_0), (x_1, y_1), ...$ を読み取って, `TraceCurveObj3D` で計算した立体をOBJ形式で標準出力する.
