### PR TITLE
複数オブジェクトに対する3Dモデル

### DIFF
--- a/MultiObj3D.hpp
+++ b/MultiObj3D.hpp
@@ -18,6 +18,7 @@ struct MultiObj3D : TraceObj3D {
         // 親クラスの初期化
     }
 
+    double stand_height = 2.0;
     std::vector<TraceObj3D*> objs;
     PointIdx stand_point_idx_begin = 0;
     PointSize stand_point_size = 0;
@@ -61,13 +62,12 @@ PointSize MultiObj3D::add_stand(double stand_z) {
     Geom::Point3 stand_size {
         std::max(exact_size.x + 2.0 * xmargin, min_length),
         std::max(exact_size.y + 2.0 * ymargin, min_length),
-        1.0
+        stand_height
     };
     double left = center.x - stand_size.x / 2.0;
     double right = center.x + stand_size.x / 2.0;
     double bottom = center.y - stand_size.y / 2.0;
     double top = center.y + stand_size.y / 2.0;
-    double stand_height = stand_size.z;
 
     stand_point_idx_begin = points.size();
     std::vector<Geom::Point3> stand_points = {

--- a/MultiObj3D.hpp
+++ b/MultiObj3D.hpp
@@ -40,22 +40,34 @@ PointSize MultiObj3D::add_stand(double stand_z) {
     double min_x = objs[0]->points[0].x;
     double max_y = objs[0]->points[0].y;
     double min_y = objs[0]->points[0].y;
+    double min_z = objs[0]->points[0].z;
+    double max_z = objs[0]->points[0].z;
     for (const auto& obj : objs) {
         for (const auto& p : obj->points) {
             max_x = std::max(max_x, p.x);
             min_x = std::min(min_x, p.x);
             max_y = std::max(max_y, p.y);
             min_y = std::min(min_y, p.y);
+            max_z = std::max(max_z, p.z);
+            min_z = std::min(min_z, p.z);
         }
     }
 
-    double xmargin = (max_x - min_x) * 0.2;
-    double ymargin = (max_y - min_y) * 0.2;
-    double left = min_x - xmargin;
-    double right = max_x + xmargin;
-    double bottom = min_y - ymargin;
-    double top = max_y + ymargin;
-    double stand_height = 10;
+    Geom::Point3 exact_size { max_x - min_x, max_y - min_y, max_z - min_z };
+    Geom::Point3 center { min_x + exact_size.x / 2.0, min_y + exact_size.y / 2.0, min_z + exact_size.z / 2.0, };
+    double xmargin = exact_size.x * 0.2;
+    double ymargin = exact_size.y * 0.2;
+    double min_length = exact_size.z / 3.0;
+    Geom::Point3 stand_size {
+        std::max(exact_size.x + 2.0 * xmargin, min_length),
+        std::max(exact_size.y + 2.0 * ymargin, min_length),
+        1.0
+    };
+    double left = center.x - stand_size.x / 2.0;
+    double right = center.x + stand_size.x / 2.0;
+    double bottom = center.y - stand_size.y / 2.0;
+    double top = center.y + stand_size.y / 2.0;
+    double stand_height = stand_size.z;
 
     stand_point_idx_begin = points.size();
     std::vector<Geom::Point3> stand_points = {

--- a/MultiObj3D.hpp
+++ b/MultiObj3D.hpp
@@ -22,7 +22,10 @@ struct MultiObj3D : TraceObj3D {
     PointIdx stand_point_idx_begin = 0;
     PointSize stand_point_size = 0;
 
-    bool make_points() override { return false; } // スタンドの追加は点と面を同一の場所で追加すべきなので make_points は定義しない
+    // スタンドの追加は点と面を同一の場所で追加すべきなので定義しない
+    bool make_points() override { return false; }
+    bool make_faces_from_slices() override { return false; }
+    bool from_slices() override { return false; }
 
     PointSize add_obj_points();
     PointSize add_stand(PointSize offset, double stand_z);

--- a/MultiObj3D.hpp
+++ b/MultiObj3D.hpp
@@ -7,13 +7,11 @@ struct MultiObj3D : TraceObj3D {
         if (_objs.size() == 0) return;
         objs = _objs;
         points.clear(); faces.clear();
-        PointSize stand_point_offset = add_obj_points();
-
-        std::tuple<double, PointSize> attach_info = attach_stand_objs();
-        stand_point_offset += std::get<PointSize>(attach_info);
-        add_stand(stand_point_offset, std::get<double>(attach_info));
+        double stand_z = attach_stand_objs();
+        add_obj_points();
 
         add_shifted_face(0);
+        add_stand(stand_z);
 
         // 親クラスの初期化
     }
@@ -28,12 +26,12 @@ struct MultiObj3D : TraceObj3D {
     bool from_slices() override { return false; }
 
     PointSize add_obj_points();
-    PointSize add_stand(PointSize offset, double stand_z);
+    PointSize add_stand(double stand_z);
     void add_shifted_face(PointSize offset);
-    std::tuple<double, PointSize> attach_stand_objs();
+    double attach_stand_objs();
 };
 
-PointSize MultiObj3D::add_stand(PointSize offset, double stand_z) {
+PointSize MultiObj3D::add_stand(double stand_z) {
     double max_x = objs[0]->points[0].x;
     double min_x = objs[0]->points[0].x;
     double max_y = objs[0]->points[0].y;
@@ -87,6 +85,7 @@ PointSize MultiObj3D::add_stand(PointSize offset, double stand_z) {
         faces.emplace_back(std::array<PointIdx, 3>{idxs[2], idxs[3], idxs[0]});
     };
 
+    PointIdx offset = stand_point_idx_begin;
     insert_rect_face({ offset + 0, offset + 4, offset + 5, offset + 1, });
     insert_rect_face({ offset + 1, offset + 5, offset + 6, offset + 2, });
     insert_rect_face({ offset + 2, offset + 6, offset + 7, offset + 3, });
@@ -135,6 +134,16 @@ void MultiObj3D::add_shifted_face(PointSize offset) {
 }
 
 // @return: stand z coordinate
-std::tuple<double, PointSize> MultiObj3D::attach_stand_objs() {
-    return { 0, 0 };
+double MultiObj3D::attach_stand_objs() {
+    int turn_step = 16;
+    double min_z = 0;
+    for (auto& obj : objs) {
+        if (auto curve_obj = dynamic_cast<TraceCenterObj3D*>(obj)) {
+            min_z = std::min(min_z, curve_obj->bend_first_edge(turn_step));
+        }
+    }
+
+    // そろえる
+
+    return min_z; // @return: stand z coordinate
 }

--- a/MultiObj3D.hpp
+++ b/MultiObj3D.hpp
@@ -1,0 +1,121 @@
+#pragma once
+#include "TraceObj3D.hpp"
+
+struct MultiObj3D : TraceObj3D {
+    MultiObj3D(const std::vector<TraceObj3D*>& _objs) {
+        if (_objs.size() == 0) return;
+        objs = _objs;
+        points.clear(); faces.clear();
+        PointSize obj_point_size = add_obj_points();
+
+        add_stand(obj_point_size);
+        add_shifted_face(0);
+        // attach_stand_objs();
+
+        // 親クラスの初期化
+    }
+    std::vector<TraceObj3D*> objs;
+
+    bool make_points() override { return false; } // スタンドの追加は点と面を同一の場所で追加すべきなので make_points は定義しない
+
+    PointSize add_obj_points();
+    PointSize add_stand(PointSize offset);
+    void add_shifted_face(PointSize offset);
+    void attach_stand_objs();
+};
+
+PointSize MultiObj3D::add_stand(PointSize offset) {
+    double max_x = objs[0]->points[0].x;
+    double min_x = objs[0]->points[0].x;
+    double max_y = objs[0]->points[0].y;
+    double min_y = objs[0]->points[0].y;
+    for (const auto& obj : objs) {
+        for (const auto& p : obj->points) {
+            max_x = std::max(max_x, p.x);
+            min_x = std::min(min_x, p.x);
+            max_y = std::max(max_y, p.y);
+            min_y = std::min(min_y, p.y);
+        }
+    }
+
+    double xmargin = (max_x - min_x) * 0.2;
+    double ymargin = (max_y - min_y) * 0.2;
+    double left = min_x - xmargin;
+    double right = max_x + xmargin;
+    double bottom = min_y - ymargin;
+    double top = max_y + ymargin;
+    double stand_height = 10;
+
+    points.emplace_back(Geom::Point3{
+        left, bottom, 0
+    });
+    points.emplace_back(Geom::Point3{
+        right, bottom, 0
+    });
+    points.emplace_back(Geom::Point3{
+        right, top, 0
+    });
+    points.emplace_back(Geom::Point3{
+        left, top, 0
+    });
+    points.emplace_back(Geom::Point3{
+        left, bottom, -stand_height
+    });
+    points.emplace_back(Geom::Point3{
+        right, bottom, -stand_height
+    });
+    points.emplace_back(Geom::Point3{
+        right, top, -stand_height
+    });
+    points.emplace_back(Geom::Point3{
+        left, top, -stand_height
+    });
+
+    // 四角形を三角形2つにする
+    auto insert_rect_face = [&](std::array<PointIdx, 4> idxs) {
+        faces.emplace_back(std::array<PointIdx, 3>{idxs[0], idxs[1], idxs[2]});
+        faces.emplace_back(std::array<PointIdx, 3>{idxs[2], idxs[3], idxs[0]});
+    };
+
+    insert_rect_face({ offset + 0, offset + 4, offset + 5, offset + 1, });
+    insert_rect_face({ offset + 1, offset + 5, offset + 6, offset + 2, });
+    insert_rect_face({ offset + 2, offset + 6, offset + 7, offset + 3, });
+    insert_rect_face({ offset + 3, offset + 7, offset + 4, offset + 0, });
+    insert_rect_face({ offset + 7, offset + 6, offset + 5, offset + 4, });
+
+    return 8; // stand point size
+}
+
+PointSize MultiObj3D::add_obj_points() {
+    PointSize obj_point_size_all = 0;
+    for (const auto& obj : objs) {
+        obj_point_size_all += obj->points.size();
+    }
+    points.reserve(obj_point_size_all);
+    for (const auto& obj : objs) {
+        points.insert(points.end(), obj->points.begin(), obj->points.end());
+    }
+    return obj_point_size_all;
+}
+
+void MultiObj3D::add_shifted_face(PointSize offset) {
+    PointSize obj_face_size = 0;
+    for (const auto& obj : objs) {
+        obj_face_size += obj->faces.size();
+    }
+    faces.reserve(obj_face_size);
+    for (const auto& obj : objs) {
+        for (const auto& face : obj->faces) {
+            // TODO: remove bottom faces
+            faces.emplace_back(std::array<PointIdx, 3>{
+                face[0] + offset,
+                face[1] + offset,
+                face[2] + offset
+            });
+        }
+        offset += obj->points.size();
+    }
+}
+
+void MultiObj3D::attach_stand_objs() {
+}

--- a/MultiObj3D.hpp
+++ b/MultiObj3D.hpp
@@ -77,12 +77,54 @@ PointSize MultiObj3D::add_stand(double stand_z) {
         faces.emplace_back(std::array<PointIdx, 3>{idxs[2], idxs[3], idxs[0]});
     };
 
-    PointIdx offset = stand_point_idx_begin;
-    insert_rect_face({ offset + 0, offset + 4, offset + 5, offset + 1, });
-    insert_rect_face({ offset + 1, offset + 5, offset + 6, offset + 2, });
-    insert_rect_face({ offset + 2, offset + 6, offset + 7, offset + 3, });
-    insert_rect_face({ offset + 3, offset + 7, offset + 4, offset + 0, });
-    insert_rect_face({ offset + 7, offset + 6, offset + 5, offset + 4, });
+    PointIdx stand_offset = stand_point_idx_begin;
+    insert_rect_face({ stand_offset + 0, stand_offset + 4, stand_offset + 5, stand_offset + 1, });
+    insert_rect_face({ stand_offset + 1, stand_offset + 5, stand_offset + 6, stand_offset + 2, });
+    insert_rect_face({ stand_offset + 2, stand_offset + 6, stand_offset + 7, stand_offset + 3, });
+    insert_rect_face({ stand_offset + 3, stand_offset + 7, stand_offset + 4, stand_offset + 0, });
+    insert_rect_face({ stand_offset + 7, stand_offset + 6, stand_offset + 5, stand_offset + 4, });
+
+    // attach face
+    std::vector<double> cap_xys;
+    std::vector<int> cap_obj_idx; // 点からそれが属するobjの添え字を得るテーブル. objs.size() の時は土台の点
+    std::vector<int> cap_obj_offset; // その点が属するobjの点がcap_xysで最初に現れる添え字
+    for (auto p : stand_points) {
+        if (p.z != stand_z) continue;
+        cap_xys.push_back(p.x);
+        cap_xys.push_back(p.y);
+        cap_obj_idx.push_back(objs.size());
+        cap_obj_offset.push_back(0);
+    }
+    for (PointIdx i = 0; i < objs.size(); i++) {
+        auto& obj = objs[i];
+        PointIdx end = first_point_face_offset[i] + obj->point_size_per_step;
+        int offset = cap_xys.size() / 2;
+        for (PointIdx j = first_point_face_offset[i]; j < end; j++) {
+            cap_xys.push_back(obj->points[j].x);
+            cap_xys.push_back(obj->points[j].y);
+            cap_obj_idx.push_back(i);
+            cap_obj_offset.push_back(offset);
+        }
+    }
+
+    delaunator::Delaunator d(cap_xys);
+    auto get_pidx = [&](PointIdx idx) -> PointIdx {
+        PointIdx obj_idx = cap_obj_idx[idx];
+        if (obj_idx == objs.size()) {
+            return idx + stand_offset;
+        }
+        PointIdx offset_in_obj = first_point_face_offset[obj_idx];
+        PointIdx relative_idx = idx - cap_obj_offset[idx];
+        return objs_point_offset[obj_idx] + offset_in_obj + relative_idx;
+    };
+
+    for (PointSize i = 0; i < d.triangles.size(); i+=3) {
+        PointIdx f1 = get_pidx(d.triangles[i]);
+        PointIdx f2 = get_pidx(d.triangles[i + 1]);
+        PointIdx f3 = get_pidx(d.triangles[i + 2]);
+        // TODO: 反時計回りか, 同じobj同士でないか判定
+        faces.emplace_back(std::array<PointIdx, 3>{f1, f3, f2});
+    }
 
     stand_point_size = 8;
     return 8; // stand point size

--- a/MultiObj3D.hpp
+++ b/MultiObj3D.hpp
@@ -106,7 +106,13 @@ void MultiObj3D::add_shifted_face(PointSize offset) {
     faces.reserve(obj_face_size);
     for (const auto& obj : objs) {
         for (const auto& face : obj->faces) {
-            // TODO: remove bottom faces
+            if (
+                face[0] >= 0 && face[0] < obj->point_size_per_step
+                && face[1] >= 0 && face[1] < obj->point_size_per_step
+                && face[2] >= 0 && face[2] < obj->point_size_per_step
+            ) {
+                continue;
+            }
             faces.emplace_back(std::array<PointIdx, 3>{
                 face[0] + offset,
                 face[1] + offset,

--- a/MultiObj3D.hpp
+++ b/MultiObj3D.hpp
@@ -7,7 +7,7 @@
 struct MultiObj3D : TraceObj3D {
     MultiObj3D(const std::vector<TraceObj3D*>& _objs) {
         if (_objs.size() == 0) return;
-        objs = _objs;
+        children = _objs;
         points.clear(); faces.clear();
         double stand_z = attach_stand_objs();
         add_obj_points();
@@ -19,7 +19,7 @@ struct MultiObj3D : TraceObj3D {
     }
 
     double stand_height = 2.0;
-    std::vector<TraceObj3D*> objs;
+    std::vector<TraceObj3D*> children;
     PointIdx stand_point_idx_begin = 0;
     PointSize stand_point_size = 0;
 
@@ -27,6 +27,9 @@ struct MultiObj3D : TraceObj3D {
     bool make_points() override { return false; }
     bool make_faces_from_slices() override { return false; }
     bool from_slices() override { return false; }
+    PointIdx push_front_step(const std::vector<Geom::Point3>& add_points) override { return 0; }
+    void add_faces(PointIdx s1, PointIdx s2) override {}
+
 
     PointSize add_obj_points();
     PointSize add_stand(double stand_z);
@@ -37,13 +40,13 @@ struct MultiObj3D : TraceObj3D {
 };
 
 PointSize MultiObj3D::add_stand(double stand_z) {
-    double max_x = objs[0]->points[0].x;
-    double min_x = objs[0]->points[0].x;
-    double max_y = objs[0]->points[0].y;
-    double min_y = objs[0]->points[0].y;
-    double min_z = objs[0]->points[0].z;
-    double max_z = objs[0]->points[0].z;
-    for (const auto& obj : objs) {
+    double max_x = children[0]->points[0].x;
+    double min_x = children[0]->points[0].x;
+    double max_y = children[0]->points[0].y;
+    double min_y = children[0]->points[0].y;
+    double min_z = children[0]->points[0].z;
+    double max_z = children[0]->points[0].z;
+    for (const auto& obj : children) {
         for (const auto& p : obj->points) {
             max_x = std::max(max_x, p.x);
             min_x = std::min(min_x, p.x);
@@ -98,17 +101,17 @@ PointSize MultiObj3D::add_stand(double stand_z) {
 
     // attach face
     std::vector<double> cap_xys;
-    std::vector<int> cap_obj_idx; // 点からそれが属するobjの添え字を得るテーブル. objs.size() の時は土台の点
+    std::vector<int> cap_obj_idx; // 点からそれが属するobjの添え字を得るテーブル. children.size() の時は土台の点
     std::vector<int> cap_obj_offset; // その点が属するobjの点がcap_xysで最初に現れる添え字
     for (auto p : stand_points) {
         if (p.z != stand_z) continue;
         cap_xys.push_back(p.x);
         cap_xys.push_back(p.y);
-        cap_obj_idx.push_back(objs.size());
+        cap_obj_idx.push_back(children.size());
         cap_obj_offset.push_back(0);
     }
-    for (PointIdx i = 0; i < objs.size(); i++) {
-        auto& obj = objs[i];
+    for (PointIdx i = 0; i < children.size(); i++) {
+        auto& obj = children[i];
         PointIdx end = first_point_face_offset[i] + obj->point_size_per_step;
         int offset = cap_xys.size() / 2;
         for (PointIdx j = first_point_face_offset[i]; j < end; j++) {
@@ -122,7 +125,7 @@ PointSize MultiObj3D::add_stand(double stand_z) {
     delaunator::Delaunator d(cap_xys);
     auto get_pidx = [&](PointIdx idx) -> PointIdx {
         PointIdx obj_idx = cap_obj_idx[idx];
-        if (obj_idx == objs.size()) {
+        if (obj_idx == children.size()) {
             return idx + stand_offset;
         }
         PointIdx offset_in_obj = first_point_face_offset[obj_idx];
@@ -151,25 +154,25 @@ PointSize MultiObj3D::add_stand(double stand_z) {
 
 PointSize MultiObj3D::add_obj_points() {
     PointSize obj_point_size_all = 0;
-    for (const auto& obj : objs) {
+    for (const auto& obj : children) {
         obj_point_size_all += obj->points.size();
     }
     points.reserve(obj_point_size_all);
-    objs_point_offset.resize(objs.size());
-    for (PointIdx i = 0; i < objs.size(); i++) {
+    objs_point_offset.resize(children.size());
+    for (PointIdx i = 0; i < children.size(); i++) {
         objs_point_offset[i] = points.size();
-        points.insert(points.end(), objs[i]->points.begin(), objs[i]->points.end());
+        points.insert(points.end(), children[i]->points.begin(), children[i]->points.end());
     }
     return obj_point_size_all;
 }
 
 void MultiObj3D::add_shifted_face(PointSize offset) {
     PointSize obj_face_size = 0;
-    for (const auto& obj : objs) {
+    for (const auto& obj : children) {
         obj_face_size += obj->faces.size();
     }
     faces.reserve(obj_face_size);
-    for (const auto& obj : objs) {
+    for (const auto& obj : children) {
         for (const auto& face : obj->faces) {
             if (
                 face[0] >= 0 && face[0] < obj->point_size_per_step
@@ -191,11 +194,11 @@ void MultiObj3D::add_shifted_face(PointSize offset) {
 // @return: stand z coordinate
 double MultiObj3D::attach_stand_objs() {
     first_point_face_offset.clear();
-    first_point_face_offset.resize(objs.size(), 0);
+    first_point_face_offset.resize(children.size(), 0);
 
     int turn_step = 16;
-    for (PointIdx i = 0; i < objs.size(); i++) {
-        if (auto curve_obj = dynamic_cast<TraceCenterObj3D*>(objs[i])) {
+    for (PointIdx i = 0; i < children.size(); i++) {
+        if (auto curve_obj = dynamic_cast<TraceCenterObj3D*>(children[i])) {
             PointIdx added_offset = curve_obj->bend_first_edge(turn_step);
             if (added_offset != 0) {
                 first_point_face_offset[i] = added_offset;
@@ -207,8 +210,8 @@ double MultiObj3D::attach_stand_objs() {
     PointIdx min_z_idx = 0;
 
     bool first_point_found = false;
-    for (PointIdx i = 0; i < objs.size(); i++) {
-        auto& obj = objs[i];
+    for (PointIdx i = 0; i < children.size(); i++) {
+        auto& obj = children[i];
         PointIdx offset = first_point_face_offset[i];
         for (PointIdx j = 0; j < obj->point_size_per_step; j++) {
             double current_z = obj->points[offset + j].z;
@@ -225,17 +228,17 @@ double MultiObj3D::attach_stand_objs() {
     }
 
     // そろえる
-    for (PointIdx i = 0; i < objs.size(); i++) {
+    for (PointIdx i = 0; i < children.size(); i++) {
         if (i == min_z_idx) continue;
 
-        auto obj = objs[i];
+        auto obj = children[i];
         PointSize psize = obj->point_size_per_step;
         std::vector<Geom::Point3> add_ps(psize);
         for (PointIdx j = 0; j < psize; j++) {
             add_ps[j] = obj->points[first_point_face_offset[i] + j];
             add_ps[j].z = min_z;
         }
-        first_point_face_offset[i] = objs[i]->push_front_step(add_ps);
+        first_point_face_offset[i] = children[i]->push_front_step(add_ps);
     }
 
     return min_z;

--- a/MultiObj3D.hpp
+++ b/MultiObj3D.hpp
@@ -1,6 +1,8 @@
 #pragma once
 #include "TraceObj3D.hpp"
+#include "delaunator.hpp"
 #include <tuple>
+#include <limits>
 
 struct MultiObj3D : TraceObj3D {
     MultiObj3D(const std::vector<TraceObj3D*>& _objs) {
@@ -29,6 +31,8 @@ struct MultiObj3D : TraceObj3D {
     PointSize add_stand(double stand_z);
     void add_shifted_face(PointSize offset);
     double attach_stand_objs();
+    std::vector<PointSize> objs_point_offset;
+    std::vector<PointSize> first_point_face_offset;
 };
 
 PointSize MultiObj3D::add_stand(double stand_z) {
@@ -102,8 +106,10 @@ PointSize MultiObj3D::add_obj_points() {
         obj_point_size_all += obj->points.size();
     }
     points.reserve(obj_point_size_all);
-    for (const auto& obj : objs) {
-        points.insert(points.end(), obj->points.begin(), obj->points.end());
+    objs_point_offset.resize(objs.size());
+    for (PointIdx i = 0; i < objs.size(); i++) {
+        objs_point_offset[i] = points.size();
+        points.insert(points.end(), objs[i]->points.begin(), objs[i]->points.end());
     }
     return obj_point_size_all;
 }
@@ -135,31 +141,53 @@ void MultiObj3D::add_shifted_face(PointSize offset) {
 
 // @return: stand z coordinate
 double MultiObj3D::attach_stand_objs() {
+    first_point_face_offset.clear();
+    first_point_face_offset.resize(objs.size(), 0);
+
     int turn_step = 16;
-    double min_z = 0;
-    PointIdx min_z_idx = 0;
     for (PointIdx i = 0; i < objs.size(); i++) {
         if (auto curve_obj = dynamic_cast<TraceCenterObj3D*>(objs[i])) {
-            double tmp = curve_obj->bend_first_edge(turn_step);
-            if (tmp < min_z) {
-                min_z = tmp;
-                min_z_idx = i;
+            PointIdx added_offset = curve_obj->bend_first_edge(turn_step);
+            if (added_offset != 0) {
+                first_point_face_offset[i] = added_offset;
             }
         }
+    }
+
+    double min_z = std::numeric_limits<double>::max();
+    PointIdx min_z_idx = 0;
+
+    bool first_point_found = false;
+    for (PointIdx i = 0; i < objs.size(); i++) {
+        auto& obj = objs[i];
+        PointIdx offset = first_point_face_offset[i];
+        for (PointIdx j = 0; j < obj->point_size_per_step; j++) {
+            double current_z = obj->points[offset + j].z;
+            if (!first_point_found || current_z < min_z) {
+                min_z = current_z;
+                min_z_idx = i;
+                first_point_found = true;
+            }
+        }
+    }
+    if (!first_point_found) {
+        min_z = 0;
+        min_z_idx = 0;
     }
 
     // そろえる
     for (PointIdx i = 0; i < objs.size(); i++) {
         if (i == min_z_idx) continue;
+
         auto obj = objs[i];
         PointSize psize = obj->point_size_per_step;
         std::vector<Geom::Point3> add_ps(psize);
         for (PointIdx j = 0; j < psize; j++) {
-            add_ps[j] = obj->points[obj->front_face_idx * psize + j];
+            add_ps[j] = obj->points[first_point_face_offset[i] + j];
             add_ps[j].z = min_z;
         }
-        objs[i]->push_front_step(add_ps);
+        first_point_face_offset[i] = objs[i]->push_front_step(add_ps);
     }
 
-    return min_z; // @return: stand z coordinate
+    return min_z;
 }

--- a/MultiObj3D.hpp
+++ b/MultiObj3D.hpp
@@ -119,11 +119,18 @@ PointSize MultiObj3D::add_stand(double stand_z) {
     };
 
     for (PointSize i = 0; i < d.triangles.size(); i+=3) {
-        PointIdx f1 = get_pidx(d.triangles[i]);
-        PointIdx f2 = get_pidx(d.triangles[i + 1]);
-        PointIdx f3 = get_pidx(d.triangles[i + 2]);
-        // TODO: 反時計回りか, 同じobj同士でないか判定
-        faces.emplace_back(std::array<PointIdx, 3>{f1, f3, f2});
+        PointIdx tri1 = d.triangles[i];
+        PointIdx tri2 = d.triangles[i + 1];
+        PointIdx tri3 = d.triangles[i + 2];
+        if (cap_obj_idx[tri1] == cap_obj_idx[tri2] && cap_obj_idx[tri2] == cap_obj_idx[tri3]) {
+            continue;
+        }
+        PointIdx p1 = get_pidx(d.triangles[i]);
+        PointIdx p2 = get_pidx(d.triangles[i + 1]);
+        PointIdx p3 = get_pidx(d.triangles[i + 2]);
+        // TODO: 反時計回りか
+        std::array<PointIdx, 3> tri = {p1, p3, p2};
+        faces.emplace_back(tri);
     }
 
     stand_point_size = 8;

--- a/MultiObj3D.hpp
+++ b/MultiObj3D.hpp
@@ -8,23 +8,26 @@ struct MultiObj3D : TraceObj3D {
         points.clear(); faces.clear();
         PointSize obj_point_size = add_obj_points();
 
-        add_stand(obj_point_size);
+        add_stand(obj_point_size, 0);
         add_shifted_face(0);
         // attach_stand_objs();
 
         // 親クラスの初期化
     }
+
     std::vector<TraceObj3D*> objs;
+    PointIdx stand_point_idx_begin = 0;
+    PointSize stand_point_size = 0;
 
     bool make_points() override { return false; } // スタンドの追加は点と面を同一の場所で追加すべきなので make_points は定義しない
 
     PointSize add_obj_points();
-    PointSize add_stand(PointSize offset);
+    PointSize add_stand(PointSize offset, double stand_z);
     void add_shifted_face(PointSize offset);
     void attach_stand_objs();
 };
 
-PointSize MultiObj3D::add_stand(PointSize offset) {
+PointSize MultiObj3D::add_stand(PointSize offset, double stand_z) {
     double max_x = objs[0]->points[0].x;
     double min_x = objs[0]->points[0].x;
     double max_y = objs[0]->points[0].y;
@@ -46,29 +49,30 @@ PointSize MultiObj3D::add_stand(PointSize offset) {
     double top = max_y + ymargin;
     double stand_height = 10;
 
+    stand_point_idx_begin = points.size();
     points.emplace_back(Geom::Point3{
-        left, bottom, 0
+        left, bottom, stand_z
     });
     points.emplace_back(Geom::Point3{
-        right, bottom, 0
+        right, bottom, stand_z
     });
     points.emplace_back(Geom::Point3{
-        right, top, 0
+        right, top, stand_z
     });
     points.emplace_back(Geom::Point3{
-        left, top, 0
+        left, top, stand_z
     });
     points.emplace_back(Geom::Point3{
-        left, bottom, -stand_height
+        left, bottom, stand_z - stand_height
     });
     points.emplace_back(Geom::Point3{
-        right, bottom, -stand_height
+        right, bottom, stand_z - stand_height
     });
     points.emplace_back(Geom::Point3{
-        right, top, -stand_height
+        right, top, stand_z - stand_height
     });
     points.emplace_back(Geom::Point3{
-        left, top, -stand_height
+        left, top, stand_z - stand_height
     });
 
     // 四角形を三角形2つにする
@@ -83,6 +87,7 @@ PointSize MultiObj3D::add_stand(PointSize offset) {
     insert_rect_face({ offset + 3, offset + 7, offset + 4, offset + 0, });
     insert_rect_face({ offset + 7, offset + 6, offset + 5, offset + 4, });
 
+    stand_point_size = 8;
     return 8; // stand point size
 }
 

--- a/MultiObj3D.hpp
+++ b/MultiObj3D.hpp
@@ -1,16 +1,19 @@
 #pragma once
 #include "TraceObj3D.hpp"
+#include <tuple>
 
 struct MultiObj3D : TraceObj3D {
     MultiObj3D(const std::vector<TraceObj3D*>& _objs) {
         if (_objs.size() == 0) return;
         objs = _objs;
         points.clear(); faces.clear();
-        PointSize obj_point_size = add_obj_points();
+        PointSize stand_point_offset = add_obj_points();
 
-        add_stand(obj_point_size, 0);
+        std::tuple<double, PointSize> attach_info = attach_stand_objs();
+        stand_point_offset += std::get<PointSize>(attach_info);
+        add_stand(stand_point_offset, std::get<double>(attach_info));
+
         add_shifted_face(0);
-        // attach_stand_objs();
 
         // 親クラスの初期化
     }
@@ -24,7 +27,7 @@ struct MultiObj3D : TraceObj3D {
     PointSize add_obj_points();
     PointSize add_stand(PointSize offset, double stand_z);
     void add_shifted_face(PointSize offset);
-    void attach_stand_objs();
+    std::tuple<double, PointSize> attach_stand_objs();
 };
 
 PointSize MultiObj3D::add_stand(PointSize offset, double stand_z) {
@@ -128,5 +131,7 @@ void MultiObj3D::add_shifted_face(PointSize offset) {
     }
 }
 
-void MultiObj3D::attach_stand_objs() {
+// @return: stand z coordinate
+std::tuple<double, PointSize> MultiObj3D::attach_stand_objs() {
+    return { 0, 0 };
 }

--- a/MultiObj3D.hpp
+++ b/MultiObj3D.hpp
@@ -137,13 +137,29 @@ void MultiObj3D::add_shifted_face(PointSize offset) {
 double MultiObj3D::attach_stand_objs() {
     int turn_step = 16;
     double min_z = 0;
-    for (auto& obj : objs) {
-        if (auto curve_obj = dynamic_cast<TraceCenterObj3D*>(obj)) {
-            min_z = std::min(min_z, curve_obj->bend_first_edge(turn_step));
+    PointIdx min_z_idx = 0;
+    for (PointIdx i = 0; i < objs.size(); i++) {
+        if (auto curve_obj = dynamic_cast<TraceCenterObj3D*>(objs[i])) {
+            double tmp = curve_obj->bend_first_edge(turn_step);
+            if (tmp < min_z) {
+                min_z = tmp;
+                min_z_idx = i;
+            }
         }
     }
 
     // そろえる
+    for (PointIdx i = 0; i < objs.size(); i++) {
+        if (i == min_z_idx) continue;
+        auto obj = objs[i];
+        PointSize psize = obj->point_size_per_step;
+        std::vector<Geom::Point3> add_ps(psize);
+        for (PointIdx j = 0; j < psize; j++) {
+            add_ps[j] = obj->points[obj->front_face_idx * psize + j];
+            add_ps[j].z = min_z;
+        }
+        objs[i]->push_front_step(add_ps);
+    }
 
     return min_z; // @return: stand z coordinate
 }

--- a/MultiObj3D.hpp
+++ b/MultiObj3D.hpp
@@ -58,30 +58,18 @@ PointSize MultiObj3D::add_stand(double stand_z) {
     double stand_height = 10;
 
     stand_point_idx_begin = points.size();
-    points.emplace_back(Geom::Point3{
-        left, bottom, stand_z
-    });
-    points.emplace_back(Geom::Point3{
-        right, bottom, stand_z
-    });
-    points.emplace_back(Geom::Point3{
-        right, top, stand_z
-    });
-    points.emplace_back(Geom::Point3{
-        left, top, stand_z
-    });
-    points.emplace_back(Geom::Point3{
-        left, bottom, stand_z - stand_height
-    });
-    points.emplace_back(Geom::Point3{
-        right, bottom, stand_z - stand_height
-    });
-    points.emplace_back(Geom::Point3{
-        right, top, stand_z - stand_height
-    });
-    points.emplace_back(Geom::Point3{
-        left, top, stand_z - stand_height
-    });
+    std::vector<Geom::Point3> stand_points = {
+        Geom::Point3{ left, bottom, stand_z },
+        Geom::Point3{ right, bottom, stand_z },
+        Geom::Point3{ right, top, stand_z },
+        Geom::Point3{ left, top, stand_z },
+        Geom::Point3{ left, bottom, stand_z - stand_height },
+        Geom::Point3{ right, bottom, stand_z - stand_height },
+        Geom::Point3{ right, top, stand_z - stand_height },
+        Geom::Point3{ left, top, stand_z - stand_height },
+    };
+
+    points.insert(points.end(), stand_points.begin(), stand_points.end());
 
     // 四角形を三角形2つにする
     auto insert_rect_face = [&](std::array<PointIdx, 4> idxs) {

--- a/TraceCenterObj3D.hpp
+++ b/TraceCenterObj3D.hpp
@@ -100,9 +100,6 @@ Geom::Point3 TraceCenterObj3D::make_points_from_norm(const Geom::Point3& n, cons
 }
 
 bool TraceCenterObj3D::make_points() {
-    PointSize slice_size = slices.size();
-    if (slice_size == 0) { return false; }
-    PointSize slice_point_size = slices[0].points.size();
 
     Geom::Point3 first_n {
         center_points[1].x - center_points[0].x,

--- a/TraceCenterObj3D.hpp
+++ b/TraceCenterObj3D.hpp
@@ -61,12 +61,14 @@ struct TraceCenterObj3D : public TraceObj3D {
     Geom::Point3 make_points_from_norm(const Geom::Point3& n, const Geom::Point3& t, const Geom::Point3& a, const std::vector<Geom::Point2>& points2D);
     bool check_intersect(std::vector<PointIdx>& intercect_step_info) const;
     bool is_front_points(const Geom::Point3& n, const Geom::Point3& o, PointIdx start, PointIdx end) const;
-    double add_first_end(const Geom::Point3& n);
+    PointIdx add_first_end(const Geom::Point3& n);
     Geom::Point3 first_face_y_axis;
-    double bend_first_edge(int turn_step);
+    PointIdx bend_first_edge(int turn_step);
 };
 
-double TraceCenterObj3D::bend_first_edge(int turn_step) {
+// @return: offset of added point
+PointIdx TraceCenterObj3D::bend_first_edge(int turn_step) {
+    PointIdx added_offset = 0;
     double pi = std::acos(-1);
     double d_theta = pi / (turn_step * 2.0);
     double cos_t = std::cos(d_theta);
@@ -82,7 +84,6 @@ double TraceCenterObj3D::bend_first_edge(int turn_step) {
     double u, v, nextu, nextv;
     double d = 1;
     int ct = 0;
-    double min_z = 0;
     while (ct++ < turn_step && 1 + n.z > 1e-4) {
         vec_u.x = n.x; vec_u.y = n.y; vec_u.z = 0;
         vec_u.normalize();
@@ -95,25 +96,23 @@ double TraceCenterObj3D::bend_first_edge(int turn_step) {
         n.z = nextu * vec_u.z + nextv;
         n.normalize();
         n.x *= d; n.y *= d; n.z *= d;
-        min_z = std::min(min_z, add_first_end(n));
+        added_offset = add_first_end(n);
     }
-    return min_z;
+    return added_offset;
 }
 
-double TraceCenterObj3D::add_first_end(const Geom::Point3& n) {
+// @return: offset of added point
+PointIdx TraceCenterObj3D::add_first_end(const Geom::Point3& n) {
+    std::cerr << "called\n";
     Geom::Point3 a = center_points[front_face_idx];
     a.x += n.x; a.y += n.y; a.z += n.z;
     Geom::Point3 n_ {-n.x, -n.y, -n.z};
     first_face_y_axis = make_points_from_norm(n_, first_face_y_axis, a, slices.begin()->points);
-    double min_z = 0;
-    for (PointIdx i = points.size() - point_size_per_step; i < points.size(); i++) {
-        min_z = std::min(min_z, points[i].z);
-    }
     add_faces(step_size, front_face_idx);
     front_face_idx = step_size;
     step_size++;
     center_points.push_back(a);
-    return min_z;
+    return points.size() - slices.begin()->points.size();
 }
 
 void TraceCenterObj3D::make_norm_vecs() {

--- a/TraceCenterObj3D.hpp
+++ b/TraceCenterObj3D.hpp
@@ -146,7 +146,7 @@ bool TraceCenterObj3D::make_points() {
     if (!check_intersect(intercect_step_info)) {
         std::cerr << count_make_point_call << "回目: " << intercect_step_info.size() << " ステップの交差を検出\n";
         double offset = 0.0;
-        double eps = 1e-3;
+        double eps = 1e-4;
         PointIdx isi = 0;
         for (PointIdx i = intercect_step_info[isi]; i < center_points.size(); i++) {
             if (isi < intercect_step_info.size() && i == intercect_step_info[isi]) {

--- a/TraceCenterObj3D.hpp
+++ b/TraceCenterObj3D.hpp
@@ -160,23 +160,20 @@ bool TraceCenterObj3D::is_front_points(const Geom::Point3& n, const Geom::Point3
 }
 
 bool TraceCenterObj3D::check_intersect() const {
+    // 最初の面をチェック
+    if (!is_front_points(
+        Geom::Point3{ -norm_vecs[0].x, -norm_vecs[0].y, -norm_vecs[0].z },
+        center_points[0],
+        0, point_size_per_step
+    )) {
+        return false;
+    }
     for (PointSize i = 0; i < norm_vecs.size(); i++) {
-        PointIdx start = point_size_per_step * i;
-        PointIdx end = point_size_per_step * (i + 1);
-        if (!is_front_points(
-            Geom::Point3{
-                - norm_vecs[i].x, - norm_vecs[i].y, - norm_vecs[i].z
-            },
-            center_points[i + 1], // 最初の点を除く
-            start, end)
-        ) {
-            return false;
-        }
-        start = point_size_per_step * (i + 2);
-        end = point_size_per_step * (i + 3);
+        PointIdx start = point_size_per_step * (i + 2);
+        PointIdx end = point_size_per_step * (i + 3);
         if (!is_front_points(
             norm_vecs[i],
-            center_points[i + 1], // 最初の点を除く
+            center_points[i + 1], // 最初の面を除く
             start, end)
         ) {
             return false;

--- a/TraceCenterObj3D.hpp
+++ b/TraceCenterObj3D.hpp
@@ -61,7 +61,60 @@ struct TraceCenterObj3D : public TraceObj3D {
     Geom::Point3 make_points_from_norm(const Geom::Point3& n, const Geom::Point3& t, const Geom::Point3& a, const std::vector<Geom::Point2>& points2D);
     bool check_intersect(std::vector<PointIdx>& intercect_step_info) const;
     bool is_front_points(const Geom::Point3& n, const Geom::Point3& o, PointIdx start, PointIdx end) const;
+    double add_first_end(const Geom::Point3& n);
+    Geom::Point3 first_face_y_axis;
+    double bend_first_edge(int turn_step);
 };
+
+double TraceCenterObj3D::bend_first_edge(int turn_step) {
+    double pi = std::acos(-1);
+    double d_theta = pi / (turn_step * 2.0);
+    double cos_t = std::cos(d_theta);
+    double sin_t = std::sin(d_theta);
+    Geom::Point3 n {
+        center_points[0].x - center_points[1].x,
+        center_points[0].y - center_points[1].y,
+        center_points[0].z - center_points[1].z
+    };
+    n.normalize();
+
+    Geom::Point3 vec_u;
+    double u, v, nextu, nextv;
+    double d = 1;
+    int ct = 0;
+    double min_z = 0;
+    while (ct++ < turn_step && 1 + n.z > 1e-4) {
+        vec_u.x = n.x; vec_u.y = n.y; vec_u.z = 0;
+        vec_u.normalize();
+        u = Geom::dot_prod(vec_u, n);
+        v = n.z;
+        nextu = cos_t * u + sin_t * v;
+        nextv = -sin_t * u + cos_t * v;
+        n.x = nextu * vec_u.x;
+        n.y = nextu * vec_u.y;
+        n.z = nextu * vec_u.z + nextv;
+        n.normalize();
+        n.x *= d; n.y *= d; n.z *= d;
+        min_z = std::min(min_z, add_first_end(n));
+    }
+    return min_z;
+}
+
+double TraceCenterObj3D::add_first_end(const Geom::Point3& n) {
+    Geom::Point3 a = center_points[front_face_idx];
+    a.x += n.x; a.y += n.y; a.z += n.z;
+    Geom::Point3 n_ {-n.x, -n.y, -n.z};
+    first_face_y_axis = make_points_from_norm(n_, first_face_y_axis, a, slices.begin()->points);
+    double min_z = 0;
+    for (PointIdx i = points.size() - point_size_per_step; i < points.size(); i++) {
+        min_z = std::min(min_z, points[i].z);
+    }
+    add_faces(step_size, front_face_idx);
+    front_face_idx = step_size;
+    step_size++;
+    center_points.push_back(a);
+    return min_z;
+}
 
 void TraceCenterObj3D::make_norm_vecs() {
     norm_vecs.clear();
@@ -118,6 +171,7 @@ bool TraceCenterObj3D::make_points() {
         center_points[0],
         slices[0].points
     );
+    first_face_y_axis = t;
 
     make_norm_vecs();
     for (PointSize i = 0; i < norm_vecs.size(); i++) {

--- a/TraceCenterObj3D.hpp
+++ b/TraceCenterObj3D.hpp
@@ -56,9 +56,10 @@ struct TraceCenterObj3D : public TraceObj3D {
     std::vector<Geom::Point3> norm_vecs;
     bool is_same_slice = false;
     bool make_points() override;
+    int count_make_point_call = 0;
     void make_norm_vecs();
     Geom::Point3 make_points_from_norm(const Geom::Point3& n, const Geom::Point3& t, const Geom::Point3& a, const std::vector<Geom::Point2>& points2D);
-    bool check_intersect() const;
+    bool check_intersect(std::vector<PointIdx>& intercect_step_info) const;
     bool is_front_points(const Geom::Point3& n, const Geom::Point3& o, PointIdx start, PointIdx end) const;
 };
 
@@ -101,6 +102,10 @@ Geom::Point3 TraceCenterObj3D::make_points_from_norm(const Geom::Point3& n, cons
 
 bool TraceCenterObj3D::make_points() {
 
+    count_make_point_call++;
+    points.clear();
+    norm_vecs.clear();
+
     Geom::Point3 first_n {
         center_points[1].x - center_points[0].x,
         center_points[1].y - center_points[0].y,
@@ -137,9 +142,20 @@ bool TraceCenterObj3D::make_points() {
         slices.back().points
     );
 
-    if (!check_intersect()) {
-        std::cerr << "交差を検出\n";
-        return false;
+    std::vector<PointIdx> intercect_step_info;
+    if (!check_intersect(intercect_step_info)) {
+        std::cerr << count_make_point_call << "回目: " << intercect_step_info.size() << " ステップの交差を検出\n";
+        double offset = 0.0;
+        double eps = 1e-3;
+        PointIdx isi = 0;
+        for (PointIdx i = intercect_step_info[isi]; i < center_points.size(); i++) {
+            if (isi < intercect_step_info.size() && i == intercect_step_info[isi]) {
+                offset += eps;
+                isi++;
+            }
+            center_points[i].z += offset;
+        }
+        make_points();
     }
 
     return true;
@@ -159,25 +175,29 @@ bool TraceCenterObj3D::is_front_points(const Geom::Point3& n, const Geom::Point3
     return true;
 }
 
-bool TraceCenterObj3D::check_intersect() const {
+bool TraceCenterObj3D::check_intersect(std::vector<PointIdx>& intercect_step_info) const {
     // 最初の面をチェック
-    if (!is_front_points(
+    PointSize origin_size = intercect_step_info.size();
+    bool is_front = is_front_points(
         Geom::Point3{ -norm_vecs[0].x, -norm_vecs[0].y, -norm_vecs[0].z },
-        center_points[0],
+        center_points[1],
         0, point_size_per_step
-    )) {
-        return false;
+    );
+    if (!is_front) {
+        intercect_step_info.push_back(1); // オフセットを追加する面
     }
+
     for (PointSize i = 0; i < norm_vecs.size(); i++) {
         PointIdx start = point_size_per_step * (i + 2);
         PointIdx end = point_size_per_step * (i + 3);
-        if (!is_front_points(
+        is_front = is_front_points(
             norm_vecs[i],
             center_points[i + 1], // 最初の面を除く
-            start, end)
-        ) {
-            return false;
+            start, end
+        );
+        if (!is_front) {
+            intercect_step_info.push_back(i+2); // オフセットを追加する面
         }
     }
-    return true;
+    return intercect_step_info.size() == origin_size;
 }

--- a/TraceCenterObj3D.hpp
+++ b/TraceCenterObj3D.hpp
@@ -103,7 +103,6 @@ PointIdx TraceCenterObj3D::bend_first_edge(int turn_step) {
 
 // @return: offset of added point
 PointIdx TraceCenterObj3D::add_first_end(const Geom::Point3& n) {
-    std::cerr << "called\n";
     Geom::Point3 a = center_points[front_face_idx];
     a.x += n.x; a.y += n.y; a.z += n.z;
     Geom::Point3 n_ {-n.x, -n.y, -n.z};

--- a/TraceObj3D.hpp
+++ b/TraceObj3D.hpp
@@ -64,7 +64,7 @@ bool TraceObj3D::make_side_faces() {
 }
 
 bool TraceObj3D::make_top_bottom_face() {
-    if (step_size == 0) { false; }
+    if (step_size == 0) { return false; }
 
     // 三角形分割
     std::vector<double> begin_face_xy(point_size_per_step * 2);
@@ -87,14 +87,16 @@ bool TraceObj3D::make_top_bottom_face() {
     end_face.reserve(d2.triangles.size()/3);
     for (PointSize i = 0; i < d1.triangles.size(); i+=3) {
         begin_face.push_back({
-            d1.triangles[i], d1.triangles[i+1], d1.triangles[i+2]
+            static_cast<unsigned long>(d1.triangles[i]),
+            static_cast<unsigned long>(d1.triangles[i+1]),
+            static_cast<unsigned long>(d1.triangles[i+2])
         });
     }
     for (PointSize i = 0; i < d2.triangles.size(); i+=3) {
         end_face.push_back({
-            d2.triangles[i] + end_fece_offset,
-            d2.triangles[i+1] + end_fece_offset,
-            d2.triangles[i+2] + end_fece_offset
+            static_cast<unsigned long>(d2.triangles[i] + end_fece_offset),
+            static_cast<unsigned long>(d2.triangles[i+1] + end_fece_offset),
+            static_cast<unsigned long>(d2.triangles[i+2] + end_fece_offset)
         });
     }
 

--- a/TraceObj3D.hpp
+++ b/TraceObj3D.hpp
@@ -28,7 +28,7 @@ struct TraceObj3D {
     virtual bool from_slices();
     virtual bool make_faces_from_slices();
 
-    void push_front_step(const std::vector<Geom::Point3>& add_points);
+    PointIdx push_front_step(const std::vector<Geom::Point3>& add_points);
     void add_faces(PointIdx s1, PointIdx s2);
     PointIdx front_face_idx = 0;
 };
@@ -140,7 +140,8 @@ void TraceObj3D::add_faces(PointIdx s1, PointIdx s2) {
     }
 }
 
-void TraceObj3D::push_front_step(const std::vector<Geom::Point3>& add_points) {
+// @return: offset of added points
+PointIdx TraceObj3D::push_front_step(const std::vector<Geom::Point3>& add_points) {
     if (add_points.size() != point_size_per_step) {
         std::cerr << "attempt to push front diffrent size points\n";
         std::exit(1);
@@ -150,6 +151,7 @@ void TraceObj3D::push_front_step(const std::vector<Geom::Point3>& add_points) {
     add_faces(step_size, front_face_idx);
     front_face_idx = step_size;
     step_size++;
+    return points.size() - point_size_per_step;
 }
 
 std::ostream& operator<<(std::ostream& ost, const TraceObj3D& obj) {

--- a/TraceObj3D.hpp
+++ b/TraceObj3D.hpp
@@ -28,8 +28,9 @@ struct TraceObj3D {
     virtual bool from_slices();
     virtual bool make_faces_from_slices();
 
-    vod push_front_step(const std::vector<Geom::Point3>& add_points);
+    void push_front_step(const std::vector<Geom::Point3>& add_points);
     void add_faces(PointIdx s1, PointIdx s2);
+    PointIdx front_face_idx = 0;
 };
 
 bool TraceObj3D::make_side_faces() {
@@ -139,14 +140,15 @@ void TraceObj3D::add_faces(PointIdx s1, PointIdx s2) {
     }
 }
 
-vod TraceObj3D::push_front_step(const std::vector<Geom::Point3>& add_points) {
+void TraceObj3D::push_front_step(const std::vector<Geom::Point3>& add_points) {
     if (add_points.size() != point_size_per_step) {
         std::cerr << "attempt to push front diffrent size points\n";
         std::exit(1);
     }
 
-    points.insert(points.begin(), add_points.begin(), add_points.end());
-    add_faces(step_size, 0);
+    points.insert(points.end(), add_points.begin(), add_points.end());
+    add_faces(step_size, front_face_idx);
+    front_face_idx = step_size;
     step_size++;
 }
 

--- a/TraceObj3D.hpp
+++ b/TraceObj3D.hpp
@@ -27,6 +27,9 @@ struct TraceObj3D {
     virtual bool make_points() = 0; // 仮想関数
     virtual bool from_slices();
     virtual bool make_faces_from_slices();
+
+    vod push_front_step(const std::vector<Geom::Point3>& add_points);
+    void add_faces(PointIdx s1, PointIdx s2);
 };
 
 bool TraceObj3D::make_side_faces() {
@@ -34,31 +37,10 @@ bool TraceObj3D::make_side_faces() {
         return false;
     }
     unsigned long sideface_num = (step_size-1) * point_size_per_step;
-    faces.reserve(faces.size() + sideface_num * 4); // 各側面につき三角形4枚
+    faces.reserve(faces.size() + sideface_num * 2); // 各側面につき三角形2枚
     
-    // 四角形を三角形2つにする
-    auto rect_face = [&](std::array<PointIdx, 4> idxs) -> std::vector<std::array<PointIdx, 3>> {
-        return {
-            {idxs[0], idxs[1], idxs[2]},
-            {idxs[2], idxs[3], idxs[0]}
-        };
-    };
-
-    for (PointSize t = 1; t < step_size; t++) {
-        PointIdx cur_offset = t * point_size_per_step;
-        PointIdx pre_offset = (t-1) * point_size_per_step;
-        for (PointSize i = 1; i < point_size_per_step; i++) {
-            auto face = rect_face({
-                 cur_offset + i, cur_offset + i-1, // 今の点
-                 pre_offset + i-1, pre_offset + i // 一つ前の点
-            });
-            faces.insert(faces.end(), face.begin(), face.end());
-        }
-        auto face = rect_face({
-             cur_offset + 0, cur_offset + point_size_per_step-1, // 今の点
-             pre_offset + point_size_per_step-1, pre_offset + 0 // 一つ前の点
-        });
-        faces.insert(faces.end(), face.begin(), face.end());
+    for (PointSize t = 0; t < step_size - 1; t++) {
+        add_faces(t, t + 1);
     }
     return true;
 }
@@ -132,6 +114,40 @@ bool TraceObj3D::make_faces_from_slices() {
 bool TraceObj3D::from_slices() {
     return make_points() &&
         make_faces_from_slices();
+}
+
+// s1 より s2 が z座標が大きい
+void TraceObj3D::add_faces(PointIdx s1, PointIdx s2) {
+    // 四角形を三角形2つにする
+    auto rect_face = [&](std::array<PointIdx, 4> idxs) -> std::vector<std::array<PointIdx, 3>> {
+        return {
+            {idxs[0], idxs[1], idxs[2]},
+            {idxs[2], idxs[3], idxs[0]}
+        };
+    };
+
+    PointIdx s1_p_idx = s1 * point_size_per_step;
+    PointIdx s2_p_idx = s2 * point_size_per_step;
+    for (PointIdx i = 0; i < point_size_per_step; i++) {
+        PointIdx next = (i + 1) % point_size_per_step;
+        // auto face = rect_face({s1_p_idx + i, s2_p_idx + i, s2_p_idx + next, s1_p_idx + next});
+        auto face = rect_face({
+            s1_p_idx + i, s1_p_idx + next,
+            s2_p_idx + next, s2_p_idx + i
+        });
+        faces.insert(faces.end(), face.begin(), face.end());
+    }
+}
+
+vod TraceObj3D::push_front_step(const std::vector<Geom::Point3>& add_points) {
+    if (add_points.size() != point_size_per_step) {
+        std::cerr << "attempt to push front diffrent size points\n";
+        std::exit(1);
+    }
+
+    points.insert(points.begin(), add_points.begin(), add_points.end());
+    add_faces(step_size, 0);
+    step_size++;
 }
 
 std::ostream& operator<<(std::ostream& ost, const TraceObj3D& obj) {

--- a/TraceObj3D.hpp
+++ b/TraceObj3D.hpp
@@ -25,8 +25,8 @@ struct TraceObj3D {
     bool make_side_faces();
     bool make_top_bottom_face();
     virtual bool make_points() = 0; // 仮想関数
-    bool from_slices();
-    bool make_faces_from_slices();
+    virtual bool from_slices();
+    virtual bool make_faces_from_slices();
 };
 
 bool TraceObj3D::make_side_faces() {

--- a/TraceObj3D.hpp
+++ b/TraceObj3D.hpp
@@ -28,8 +28,8 @@ struct TraceObj3D {
     virtual bool from_slices();
     virtual bool make_faces_from_slices();
 
-    PointIdx push_front_step(const std::vector<Geom::Point3>& add_points);
-    void add_faces(PointIdx s1, PointIdx s2);
+    virtual PointIdx push_front_step(const std::vector<Geom::Point3>& add_points);
+    virtual void add_faces(PointIdx s1, PointIdx s2);
     PointIdx front_face_idx = 0;
 };
 


### PR DESCRIPTION
# 複数オブジェクトに対する3Dモデル

## `MultiObj3D` の追加

複数の `TraceObj3D` を土台でつなげる.
`TraceObj3D` を継承する.

メンバ:
- `double stand_height = 2.0`
    - 土台のz軸方向の高さ
- `std::vector<TraceObj3D*> children`
    - 生成するオブジェクト
- `PointIdx stand_point_idx_begin = 0`
    - `points` の中で土台を作る点が始まる添え字
    - `points` は `TraceObj3D` から継承されるメンバ
- `PointSize stand_point_size = 0`
    - 土台を作る点の個数
- `std::vector<PointSize> objs_point_offset`
    - それぞれのオブジェクトを構成する点が `points` に現れる最初の添え字
    - `children[i]` の点は `points[objs_point_offset[i]]` から `points[objs_point_offset[i] + children[i]->points.size()]` に保存される
- `std::vector<PointSize> first_point_face_offset`
    - それぞれのオブジェクトの最も土台に近いステップを構成する点がそれぞれの `points` に現れる最初の添え字
    - `children[i]` の最も土台に近いステップは `points[objs_point_offset[i] + first_point_face_offset[i]]` から `points[objs_point_offset[i] + first_point_face_offset[i] + children[i]->point_size_per_step]` に保存される

メゾッド:

- `PointSize add_obj_points()`
    - `points` に `children` の点を追加しながら, `objs_point_offset` を更新する
    - 戻り値は追加した点の数
- `PointSize add_stand(double stand_z)`
    - 土台の点と面を追加する
    - 引数 `stand_z` を基準に$z = \text{stand_z}$ の平面が各オブジェクトと土台の接続する面になる
    - オブジェクトと土台の接続する面以外の面
        - 単純に添え字に沿って面を作る
    - オブジェクトと土台の接続する面
        - 土台の点とオブジェクトの最も土台に近い点の三角形分割で面を作る
        - 属するオブジェクトが同じ点同士をつなぐ辺は除外
- `void add_shifted_face(PointSize offset)`
    - 各オブジェクトの面を `points` に対応するようにずらしながら `faces` に追加する
    - `children[i]` のオフセットは引数 `offset` に `children[0]` から `children[i-1]` の点の個数を全て足したもの
- `double attach_stand_objs()`
    - 子のオブジェクトが `TraceCenterObj3D` を継承している場合, 土台に接続する端を $-z$ 方向に曲げる
        - 子オブジェクトの `bend_first_edge` を呼ぶ
    - 全ての子オブジェクトの土台に近いステップの $z$ 座標を最も小さいものにそろえる
- コンストラクタ
    - `attach_stand_objs`, `add_obj_points`, `add_shifted_face`, `add_stand` の順に呼び, OBJ に必要な値を計算する

使用しない親クラスのメゾッド:

- `bool make_points()`
- `bool make_faces_from_slices()`
- `bool from_slices()`
- `PointIdx push_front_step(const std::vector<Geom::Point3>& add_points)`
- `void add_faces(PointIdx s1, PointIdx s2)`

## `TraceObj3D`, `TraceCurveObj3D` の変更点

- `PointIdx TraceObj3D::push_front_step(const std::vector<Geom::Point3>& add_points)`
    - 先頭方向にステップを追加する
    - 実際に `points` の先頭に追加はせず, 末尾に追加した後 `front_face_idx` を適切に更新する
- `void TraceObj3D::add_faces(PointIdx s1, PointIdx s2)`
    - `s1` 番目のステップと `s2` 番目のステップの間の側面を追加する
    - 通常の `make_side_faces` の処理も `add_faces` を用いるようにした
- `PointIdx TraceCenterObj3D::bend_first_edge(int turn_step)`
    - 最高 `turn_step` 個のステップを追加し, $-z$ 方向に曲げる
    - 方法は 下記[オブジェクトの端を指定の方向に曲げる](#オブジェクトの端を指定の方向に曲げる) を参照
- `PointIdx TraceCenterObj3D::add_first_end(const Geom::Point3& n)`
    - 先頭のステップを `n` 方向に `n` の大きさ分動かしたステップを追加する
        - 先頭ステップの各点に `n` を加えた点を `points` に追加
        - 追加したステップと先頭のステップの間の側面を `add_faces` で追加
        - `front_face_idx` と `step_size` を更新
    - 注意: 側面以外の面については管理しない


## オブジェクトの端を指定の方向に曲げる

曲げる方向を表すベクトルを $\mathbf{u}$, 今の面の法線ベクトルを $\mathbf{n}$ とする.
それぞれ $|\mathbf{u}| = |\mathbf{n}| = 1$とする.

$\mathbf{u}$ に独立な方向 $\mathbf{v}$ を定め, $\mathbf{u}$ と $\mathbf{v}$ に成分分解をして, それを回転行列によって更新する.
これによって $\mathbf{u}, \mathbf{v}$ によって張られる平面に沿って曲げることができる.

1. while True :
    1. $u := \mathbf{u} \cdot \mathbf{n}$
    2. if $|u - 1| \lt \varepsilon$: break
    3. $\tilde{\mathbf{v}} := \mathbf{n} - u \mathbf{u}$
    4. $\mathbf{v} := \tilde{\mathbf{v}} / |\tilde{\mathbf{v}}|$
    5. $v := \mathbf{v} \cdot \mathbf{n}$
    6. $(u', v')^T := M (u, v)^T$, $M$ は回転行列.
    7. $\tilde{\mathbf{n}} := u' \mathbf{u} + v' \mathbf{v}$
    8. $\mathbf{n} := \tilde{\mathbf{n}} / |\tilde{\mathbf{n}}|$

最終的な $\mathbf{n}$ が新しい面の法線ベクトルとなる.
$M$ は以下のような行列で, $\mathbf{n}$ を $\mathbf{u}$ の方向に $\theta$ だけ回転する:
```math
M := \begin{bmatrix} 
    \cos\theta & \sin\theta \\ 
    -\sin\theta & \cos\theta
  \end{bmatrix}
```