### PR TITLE
線形補間付きLayerObj3D

### DIFF
--- a/LayerObj3D.hpp
+++ b/LayerObj3D.hpp
@@ -19,7 +19,7 @@ struct LayerObj3D : public TraceObj3D {
 
 bool LayerObj3D::make_points() {
     points.clear();
-    points.reserve(slices.size() * slices[0].points.size();
+    points.reserve(slices.size() * slices[0].points.size());
     double z = 0;
     double length_per_time = TOTAL_SIZE / slices.size();
     for (PointSize i = 0; i < slices.size(); i++) {
@@ -62,7 +62,7 @@ std::istream& operator>>(std::istream& ist, LayerObj3D& obj) {
     }
 
     is_ok &= obj.check_slice_point_size();
-    is_ok &= obj.from_slices(INTERPOLATE_SIZE);
+    is_ok &= obj.from_slices(obj.INTERPOLATE_SIZE);
 
     if (!is_ok) {
         // スライスからの生成に失敗
@@ -72,13 +72,13 @@ std::istream& operator>>(std::istream& ist, LayerObj3D& obj) {
 }
 
 bool LayerObj3D::from_slices(int interpolate_size) {
-    if (INTERPOLATE_SIZE == 0) {
-        return obj.from_slices();
+    if (interpolate_size == 0) {
+        return TraceObj3D::from_slices();
     }
 
     bool is_ok = true;
     // 線形補間が指定されている場合は, 線形補間付き make_points を呼び出す
-    is_ok &= make_points(INTERPOLATE_SIZE);
+    is_ok &= make_points(interpolate_size);
     is_ok &= make_faces_from_slices();
     return is_ok;
 }

--- a/LayerObj3D.hpp
+++ b/LayerObj3D.hpp
@@ -5,8 +5,10 @@
 #include "TraceObj3D.hpp"
 
 struct LayerObj3D : public TraceObj3D {
-    double LENGTH_PER_TIME = 1;
-    LayerObj3D(double lpt) : LENGTH_PER_TIME(lpt) {};
+    double TOTAL_SIZE = 100;
+    double INTERPOLATE_SIZE = 0;
+    LayerObj3D(double _total_size) : TOTAL_SIZE(_total_size) {};
+    LayerObj3D(double _total_size, int _interpolate_size) : TOTAL_SIZE(_total_size), INTERPOLATE_SIZE(_interpolate_size) {};
     LayerObj3D() {};
     std::vector<Slice> slices;
     bool make_points() override;
@@ -17,13 +19,14 @@ bool LayerObj3D::make_points() {
     points.clear();
     points.reserve(slices.size());
     double z = 0;
+    double length_per_time = TOTAL_SIZE / slices.size();
     for (PointSize i = 0; i < slices.size(); i++) {
         for (const auto& p : slices[i].points) {
             points.emplace_back(Geom::Point3{
                 p.x, p.y, z
             });
         }
-        z += LENGTH_PER_TIME;
+        z += length_per_time;
     }
     return true;
 }

--- a/LayerObj3D.hpp
+++ b/LayerObj3D.hpp
@@ -19,7 +19,7 @@ struct LayerObj3D : public TraceObj3D {
 
 bool LayerObj3D::make_points() {
     points.clear();
-    points.reserve(slices.size());
+    points.reserve(slices.size() * slices[0].points.size();
     double z = 0;
     double length_per_time = TOTAL_SIZE / slices.size();
     for (PointSize i = 0; i < slices.size(); i++) {

--- a/LayerObj3D.hpp
+++ b/LayerObj3D.hpp
@@ -12,6 +12,8 @@ struct LayerObj3D : public TraceObj3D {
     LayerObj3D() {};
     std::vector<Slice> slices;
     bool make_points() override;
+    bool make_points(int interpolate_size);
+    bool from_slices(int interpolate_size);
     bool check_slice_point_size() const;
 };
 
@@ -60,11 +62,23 @@ std::istream& operator>>(std::istream& ist, LayerObj3D& obj) {
     }
 
     is_ok &= obj.check_slice_point_size();
-    is_ok &= obj.from_slices();
-    
+    is_ok &= obj.from_slices(INTERPOLATE_SIZE);
+
     if (!is_ok) {
         // スライスからの生成に失敗
         ist.setstate(std::ios_base::failbit);
     };
     return ist;
+}
+
+bool LayerObj3D::from_slices(int interpolate_size) {
+    if (INTERPOLATE_SIZE == 0) {
+        return obj.from_slices();
+    }
+
+    bool is_ok = true;
+    // 線形補間が指定されている場合は, 線形補間付き make_points を呼び出す
+    is_ok &= make_points(INTERPOLATE_SIZE);
+    is_ok &= make_faces_from_slices();
+    return is_ok;
 }

--- a/LayerObj3D.hpp
+++ b/LayerObj3D.hpp
@@ -33,6 +33,44 @@ bool LayerObj3D::make_points() {
     return true;
 }
 
+bool LayerObj3D::make_points(int interpolate_size) {
+    // 最後の層以外の間で interpolate_size 個の層が追加される
+    PointSize exact_slice_size = (slices.size() - 1) * (interpolate_size + 1) + 1;
+    PointSize total_point_size = exact_slice_size * slices[0].points.size();
+    points.clear();
+    points.reserve(total_point_size);
+    double length_per_time = TOTAL_SIZE / exact_slice_size;
+
+    double z = 0;
+    // 最後の層を除き, 補間しながら点を追加する
+    for (PointSize i = 0; i < slices.size() - 1; i++) {
+        for (int polate_rate = 0; polate_rate < interpolate_size + 1; polate_rate++) {
+            for (PointSize j = 0; j < slices[i].points.size(); j++) {
+                Geom::Point2 p = slices[i].points[j];
+                Geom::Point2 q = slices[i + 1].points[j];
+                double t = (double)polate_rate / (interpolate_size + 1);
+                double x = p.x * (1 - t) + q.x * t;
+                double y = p.y * (1 - t) + q.y * t;
+                points.emplace_back(Geom::Point3{
+                    x, y, z
+                });
+            }
+            z += length_per_time;
+        }
+    }
+
+    // 最後の層はそのまま追加
+    for (const auto& p : slices.back().points) {
+        points.emplace_back(Geom::Point3{
+            p.x, p.y, z
+        });
+    }
+
+    this->step_size = exact_slice_size;
+
+    return true;
+}
+
 bool LayerObj3D::check_slice_point_size() const {
     for (const auto& slice : slices) {
         if (slice.points.size() != point_size_per_step) return false;

--- a/test/test_layer_obj_3d.cpp
+++ b/test/test_layer_obj_3d.cpp
@@ -18,7 +18,7 @@ bool check_including_line(const std::set<std::string>& se, std::stringstream& ss
 }
 
 void test_obj_cube() {
-    LayerObj3D obj;
+    LayerObj3D obj(2);
     std::istringstream iss;
     iss.str("0, 0 0 1 0 1 1 0 1\n"
             "1, 0 0 1 0 1 1 0 1\n");
@@ -59,7 +59,7 @@ void test_obj_cube() {
 
 // 立方体が二つつながった図形
 void test_obj_double_cube() {
-    LayerObj3D obj;
+    LayerObj3D obj(3);
     std::istringstream iss;
     iss.str("0, 0 0 1 0 1 1 0 1\n"
             "1, 0 0 1 0 1 1 0 1\n"


### PR DESCRIPTION
# 線形補間付きLayerObj3D

`LayerObj3D` のコンストラクタに第二引数を指定すると, 入力の層の間に指定した枚数の層を等間隔に追加する.
追加した層の各点は, 対応する点の線形補間される.

使用例:
```cpp
double total_size = 100.0;
int adding_num = 10
LayerObj3D obj(total_size, adding_num);
```

第一引数は全体のサイズを指定する.
全体のサイズのみを指定することもできる.
```cpp
double total_size = 100.0;
LayerObj3D obj(total_size);
```